### PR TITLE
Use native Array#reduce method and remove Underscore from dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var lib = require('./lib');
 var errors = require('./errors');
 
@@ -63,7 +62,7 @@ PasswordSchema.prototype.validate = function (pwd) {
   var self = this;
 
   // Sets valid property after applying all validations
-  _.reduce(self.properties, function (valid, property) {
+  self.properties.reduce(function (valid, property) {
     // Applies all validations defined in lib one by one
     return lib[property.method].apply(self, property.arguments);
   }, self.valid);

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "url": "https://github.com/tarunbatra/password-validator/issues"
   },
   "homepage": "https://github.com/tarunbatra/password-validator#readme",
-  "dependencies": {
-    "underscore": "^1.8.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "chai": "^3.5.0",
     "docdash": "^0.4.0",


### PR DESCRIPTION
Currently, this module requires the whole Underscore library only to use the `reduce` method. We can avoid this dependency by using the [native `reduce` method](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce) which has a nice support and works even in IE9.

Thanks!