### PR TITLE
Allow empty strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ function PasswordValidator() {
  */
 PasswordValidator.prototype.validate = function (pwd, options) {
   // Checks if pwd is invalid
-  if (!pwd || typeof pwd !== 'string') {
+  if (typeof pwd !== 'string') {
     throw new Error(error.password);
   }
 


### PR DESCRIPTION
There is an issue if the password to check (pwd) = ""    
javascript types this as empty == false, so !pwd = true and there is an exception.