### PR TITLE
Support for non-english lower and upper cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - "6"
 - "8"
 - "10"
+- "12"
 - "node"
 install: npm install
 script: npm test

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,8 +6,6 @@ module.exports = {
   regex: {
     digits: /\d+/,
     letters: /[a-zA-Z]+/,
-    uppercase: /[A-Z]+/,
-    lowercase: /[a-z]+/,
     symbols: /[`~\!@#\$%\^\&\*\(\)\-_\=\+\[\{\}\]\\\|;:'",<.>\/\?€£¥₹]+/,
     spaces: /[\s]+/
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -85,14 +85,14 @@ module.exports = {
    * Method to validate the presence of uppercase letters
    */
   uppercase: function uppercase() {
-    return _process.call(this, regex.uppercase);
+    return this.password !== this.password.toLowerCase();
   },
 
   /**
    * Method to validate the presence of lowercase letters
    */
   lowercase: function lowercase() {
-    return _process.call(this, regex.lowercase);
+    return this.password !== this.password.toUpperCase();
   },
 
   /**


### PR DESCRIPTION
Fixes #23.

Although this fixes `lowercase` and `uppercase`. Rules like `letters` are still english only. I'm exploring browser support of [Unicode property escaped in ES2018](https://github.com/tc39/proposal-regexp-unicode-property-escapes) to make it work for all the cases in all the languages.