### PR TITLE
Small change for validator type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,10 +15,10 @@ declare class PasswordValidator {
      *           'options.details' is not set. Otherwise, it returns an
      *           array of property names which failed validations
      */
-    validate(pwd: string, options?: {
-        list?: boolean;
-        details?: boolean;
-    }): boolean | any[];
+    validate(pwd: string, options: { list: true, details: true }): string[];
+    validate(pwd: string, options: { list: true, details?: boolean }): string[];
+    validate(pwd: string, options: { list?: boolean, details: true }): string[];
+    validate(pwd: string, options?: { list?: boolean, details?: boolean }): boolean | string[];
     list: boolean;
     details: boolean;
     password: string;


### PR DESCRIPTION
Before the last updates, the Validate function had these 2 declarations

```
 validate(password: string, options: { list:true }): string[];
validate(password: string, options?: ValidateOptions): boolean | string[];
```

This was very convenient since after providing the `list: true` we could skip all the type checking. Was there a reason why this was removed in the latest pushes? This can potentially break current implementations of the library. This is exactly what happened in our project :) 

Replacing the current declaration of validate with the changes in this pull request should fix this issue.